### PR TITLE
Adds build of the VSIX package for mac-arm64 and others

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            target: darwin-x64
+            targets: "darwin-x64,darwin-arm64"
           - os: ubuntu-latest
-            target: linux-x64
+            targets: "linux-x64,linux-arm64"
           - os: windows-latest
-            target: win32-x64
+            targets: "win32-x64"
       fail-fast: false
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -56,8 +56,11 @@ jobs:
       - name: Verify coverage
         run: npm run cov
 
-      - name: Create a VSIX package for target ${{ matrix.target }}
+      - name: Create a VSIX package for targets [ ${{ matrix.targets }} ]
+        shell: bash
         run: >
-          npm run vsce:package --
-          --target ${{ matrix.target }}
-          --out ocm-vscode-extension-${{ matrix.target }}-dev.vsix
+          echo "${{ matrix.targets }}" | tr "," "\n"  |  while read  -r target; do
+            npm run vsce:package -- \
+              --target ${target} \
+              --out ocm-vscode-extension-${target}-dev.vsix
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,12 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            target: darwin-x64
+            targets: "darwin-x64,darwin-arm64"
           - os: ubuntu-latest
-            target: linux-x64
+            targets: "linux-x64,linux-arm64"
           - os: windows-latest
-            target: win32-x64
-    name: Create a VSIX package for target ${{ matrix.target }}
+            targets: "win32-x64"
+    name: Create a VSIX package for targets [ ${{ matrix.targets }} ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -82,11 +82,14 @@ jobs:
       - name: Install project modules
         run: npm ci
 
-      - name: Create VSIX package
+      - name: Create a VSIX package for targets [ ${{ matrix.targets }} ]
+        shell: bash
         run: >
-          npm run vsce:package --
-          --target ${{ matrix.target }}
-          --out ocm-vscode-extension-${{ matrix.target }}-${{ needs.prepare.outputs.new_version }}.vsix
+          echo "${{ matrix.targets }}" | tr "," "\n"  |  while read  -r target; do
+            npm run vsce:package -- \
+              --target ${target} \
+              --out ocm-vscode-extension-${target}-${{ needs.prepare.outputs.new_version }}.vsix
+          done
 
       - name: Upload VSIX package as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            target: darwin-x64
+            targets: "darwin-x64,darwin-arm64"
           - os: ubuntu-latest
-            target: linux-x64
+            targets: "linux-x64,linux-arm64"
           - os: windows-latest
-            target: win32-x64
-    name: Create a VSIX package for target ${{ matrix.target }}
+            targets: "win32-x64"
+    name: Create a VSIX package for targets [ ${{ matrix.targets }} ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -35,12 +35,14 @@ jobs:
       - name: Install project modules
         run: npm ci
 
-      - name: Create VSIX package
+      - name: Create a VSIX package for targets [ ${{ matrix.targets }} ]
+        shell: bash
         run: >
-          npm run vsce:package --
-          --pre-release
-          --target ${{ matrix.target }}
-          --out ocm-vscode-extension-${{ matrix.target }}-early-access.vsix
+          echo "${{ matrix.targets }}" | tr "," "\n"  |  while read  -r target; do
+            npm run vsce:package -- \
+              --pre-release --target ${target} \
+              --out ocm-vscode-extension-${target}-early-access.vsix
+          done
 
       - name: Upload VSIX package as artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Adds build of the VSIX package for mac-arm64, linux-arm53, win32-arm, win32-ia32

fixes #58 

After having looked at some code specificities related to architecture, I haven't find anything relevant. So, I have run the extension locally in Debug mode on my Mac Silicon and it was running like a charm. 

I think then that it is only a question of the relevant package for the target required architecture that was not available and so I added them by following this documentation:
https://www.npmjs.com/package/semantic-release-vsce#:~:text=%2D%20os%3A,target%3A%20universal

