### PR TITLE
fix: upgrade clusterset clustersetbinding to v1beta2

### DIFF
--- a/snippets/managedclusterset.json
+++ b/snippets/managedclusterset.json
@@ -1,11 +1,11 @@
 {
-	"managedclusterset-v1beta1": {
+	"managedclusterset-v1beta2": {
 		"scope": "yaml",
-		"prefix": "OCM ManagedClusterSet v1beta1",
+		"prefix": "OCM ManagedClusterSet v1beta2",
 		"description": "The managed cluster set represents a set of clusters to select from.",
 		"body": [
 			"---",
-			"apiVersion: cluster.open-cluster-management.io/v1beta1",
+			"apiVersion: cluster.open-cluster-management.io/v1beta2",
 			"kind: ManagedClusterSet",
 			"metadata:",
 			"  name: ${1:<managed-clustterset-name>}"

--- a/snippets/managedclustersetbinding.json
+++ b/snippets/managedclustersetbinding.json
@@ -1,11 +1,11 @@
 {
-	"managedclustersetbinding-v1beta1": {
+	"managedclustersetbinding-v1beta2": {
 		"scope": "yaml",
-		"prefix": "OCM ManagedClusterSetBinding v1beta1",
+		"prefix": "OCM ManagedClusterSetBinding v1beta2",
 		"description": "The managed clusters set binding is used to bind the managed clusters set to a namespace.",
 		"body": [
 			"---",
-			"apiVersion: cluster.open-cluster-management.io/v1beta1",
+			"apiVersion: cluster.open-cluster-management.io/v1beta2",
 			"kind: ManagedClusterSetBinding",
 			"metadata:",
 			"  name: ${1:<managed-clustterset-name>} # should be identical to the underlying ManagedClusterSet",

--- a/templates/Git/clusterset.yaml
+++ b/templates/Git/clusterset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   name: helloworld-clusterset

--- a/templates/Git/clustersetbinding.yaml
+++ b/templates/Git/clustersetbinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: helloworld-clusterset # the name should be identical to the underlying ManagedClusterSet

--- a/templates/HelmRepo/clusterset.yaml
+++ b/templates/HelmRepo/clusterset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   name: helloworld-clusterset

--- a/templates/HelmRepo/clustersetbinding.yaml
+++ b/templates/HelmRepo/clustersetbinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: helloworld-clusterset # the name should be identical to the underlying ManagedClusterSet

--- a/templates/ObjectBucket/clusterset.yaml
+++ b/templates/ObjectBucket/clusterset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   name: helloworld-clusterset

--- a/templates/ObjectBucket/clustersetbinding.yaml
+++ b/templates/ObjectBucket/clustersetbinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: helloworld-clusterset # the name should be identical to the underlying ManagedClusterSet


### PR DESCRIPTION
Refer to https://github.com/open-cluster-management-io/api/pull/266, the ClusterSet ClusterSetBinding API version v1beta1 has been removed, need to upgrade the API to v1beta2. 

![Screenshot 2023-10-25 at 17 31 22](https://github.com/open-cluster-management-io/ocm-vscode-extension/assets/24226678/e0f60f82-fd14-4548-b600-a23a27df2e4d)

```
---
apiVersion: cluster.open-cluster-management.io/v1beta2
kind: ManagedClusterSet
metadata:
  name: clusterset-test
---
apiVersion: cluster.open-cluster-management.io/v1beta2
kind: ManagedClusterSetBinding
metadata:
  name: clusterset-test # should be identical to the underlying ManagedClusterSet
  namespace: clusterset-test-ns
spec:
  clusterSet: clusterset-test
```
```
➜  test-workspace git:(br_clusterset-v1beta2) kubectl create -f mcs.yaml 
managedclusterset.cluster.open-cluster-management.io/clusterset-test created
managedclustersetbinding.cluster.open-cluster-management.io/clusterset-test created

➜  test-workspace git:(br_clusterset-v1beta2) kubectl get managedclusterset clusterset-test -oyaml
apiVersion: cluster.open-cluster-management.io/v1beta2
kind: ManagedClusterSet
metadata:
  creationTimestamp: "2023-10-25T09:27:40Z"
  generation: 1
  name: clusterset-test
  resourceVersion: "646001"
  uid: 328fd86b-3270-47ec-985f-71af31f90620
spec:
  clusterSelector:
    selectorType: ExclusiveClusterSetLabel
status:
  conditions:
  - lastTransitionTime: "2023-10-25T09:27:40Z"
    message: No ManagedCluster selected
    reason: NoClusterMatched
    status: "True"
    type: ClusterSetEmpty

➜  test-workspace git:(br_clusterset-v1beta2) kubectl get managedclustersetbinding -n clusterset-test-ns clusterset-test -oyaml
apiVersion: cluster.open-cluster-management.io/v1beta2
kind: ManagedClusterSetBinding
metadata:
  creationTimestamp: "2023-10-25T09:27:40Z"
  generation: 1
  name: clusterset-test
  namespace: clusterset-test-ns
  resourceVersion: "646003"
  uid: 6840b2fb-cada-4dd6-ae5c-d35637094fad
spec:
  clusterSet: clusterset-test
status:
  conditions:
  - lastTransitionTime: "2023-10-25T09:27:40Z"
    message: ""
    reason: ClusterSetBound
    status: "True"
    type: Bound
```